### PR TITLE
Moved sequelize to peerDependencies to fix incompatibility with upstream mssql tedious dialectModule 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,16 @@
   ],
   "author": "lyquocnam",
   "license": "MIT",
+  "peerDependencies": {
+    "sequelize": "^5.9.3"
+  },
   "dependencies": {
     "fastify-plugin": "^0.1.1",
-    "sequelize": "^4.20.1"
   },
   "devDependencies": {
-    "fastify": "^0.31.0",
-    "nodemon": "^1.12.1",
+    "fastify": "^2.6.0",
+    "nodemon": "^1.19.1",
     "sqlite3": "^3.1.13",
-    "tap": "^10.7.2"
+    "tap": "^14.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sequelize": "^5.9.3"
   },
   "dependencies": {
-    "fastify-plugin": "^0.1.1",
+    "fastify-plugin": "^0.1.1"
   },
   "devDependencies": {
     "fastify": "^2.6.0",


### PR DESCRIPTION
Fixes issues reported here https://github.com/sequelize/sequelize/issues/11179 I mistakenly thought this was an issue in sequelize but realized fastify-sequelize was not using the latest version - and issue is fixed upstream.
